### PR TITLE
Make this compile without Foundation in the prefix header.

### DIFF
--- a/NSObject+JCSKVOWithBlocks.h
+++ b/NSObject+JCSKVOWithBlocks.h
@@ -32,13 +32,13 @@
  
  */
 
+#import <Foundation/Foundation.h>
+
 #if !__has_feature(objc_arc)
 #warning "NSObject+JCSKVOWithBlocks only runs under ARC."
 #endif
 
 typedef void (^jcsObservationBlock)(NSDictionary *change);
-
-#import <Foundation/Foundation.h>
 
 @interface NSObject (JCSKVOWithBlocks)
 

--- a/NSObject+JCSKVOWithBlocks.m
+++ b/NSObject+JCSKVOWithBlocks.m
@@ -28,15 +28,15 @@
     #endif
 #endif
 
+#import "NSObject+JCSKVOWithBlocks.h"
+#import <objc/runtime.h>
+
 // The context for a KVO observations
 static NSString * const JCSKVOWithBlocksObservationContext = @"JCSKVOWithBlocksObservationContext";
 
 // The key under which the array of observers is stored in associated objects
 static NSString * const JCSKVOWithBlocksObserverAssociatedObjectKey = @"com.junglecandy.jcskvowithblocks";
 
-
-#import "NSObject+JCSKVOWithBlocks.h"
-#import <objc/runtime.h>
 
 #pragma mark JCSKVOObserver
 


### PR DESCRIPTION
We were using NSString and NSDictionary before we actually include them.
