### PR TITLE
Move check out of header.

### DIFF
--- a/NSObject+JCSKVOWithBlocks.h
+++ b/NSObject+JCSKVOWithBlocks.h
@@ -32,13 +32,9 @@
  
  */
 
-#if !__has_feature(objc_arc)
-#warning "NSObject+JCSKVOWithBlocks only runs under ARC."
-#endif
+#import <Foundation/Foundation.h>
 
 typedef void (^jcsObservationBlock)(NSDictionary *change);
-
-#import <Foundation/Foundation.h>
 
 @interface NSObject (JCSKVOWithBlocks)
 

--- a/NSObject+JCSKVOWithBlocks.m
+++ b/NSObject+JCSKVOWithBlocks.m
@@ -22,6 +22,10 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if !__has_feature(objc_arc)
+#warning "NSObject+JCSKVOWithBlocks only runs under ARC."
+#endif
+
 #ifndef DEBUG
     #ifndef NS_BLOCK_ASSERTIONS
         #define NS_BLOCK_ASSERTIONS


### PR DESCRIPTION
So people using -fobjc-arc in non-ARC projects can still use this class.
